### PR TITLE
Update md-dialog to use getAttribute instead of direct accessing form method

### DIFF
--- a/dialog/internal/dialog.ts
+++ b/dialog/internal/dialog.ts
@@ -371,7 +371,7 @@ export class Dialog extends dialogBaseClass {
   private handleSubmit(event: SubmitEvent) {
     const form = event.target as HTMLFormElement;
     const {submitter} = event;
-    if (form.method !== 'dialog' || !submitter) {
+    if (form.getAttribute('method') !== 'dialog' || !submitter) {
       return;
     }
 


### PR DESCRIPTION
Fixes [md-dialog: handleSubmit fails with a <input name="method" /> as dialog form child #5777
](https://github.com/material-components/material-web/issues/5777)